### PR TITLE
feat: drag'n'drop exercise

### DIFF
--- a/rxjs-playground/src/app/exercises/dragdrop/dragdrop.component.ts
+++ b/rxjs-playground/src/app/exercises/dragdrop/dragdrop.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
-import { fromEvent, concatMap, takeUntil } from 'rxjs';
+import { fromEvent, switchMap, takeUntil, merge } from 'rxjs';
 
 @Component({
   templateUrl: './dragdrop.component.html',
@@ -27,8 +27,16 @@ export class DragdropComponent implements OnInit {
      */
 
     /******************************/
+    mouseDown$.pipe(
+      switchMap(e => {
+        e.stopImmediatePropagation();
+        return mouseMove$.pipe(takeUntil(merge(mouseUp$, mouseDown$)));
+      }),
+    ).subscribe(e => {
+      e.stopImmediatePropagation();
+      this.setTargetPosition(e);
+    })
 
-    
     /******************************/
   }
 


### PR DESCRIPTION
Potential solution.
Open questions I have:
1. How to prevent text getting selected in the background when dragging the rectangle around? I hoped `stopImmediatePropagation()` would do something about that.
1. Sometimes (e.g., when clicking really fast), the rectangle gets stuck to the mouse even though no button is down. Merging the up/down events for `takeUntil` gives a fallback in that case. I obviously have a bug still, but I am unsure how to fix it.
1. How would a solution without `takeUntil` look like?